### PR TITLE
Change show page for invalid home

### DIFF
--- a/app/views/validations/show.html.erb
+++ b/app/views/validations/show.html.erb
@@ -1,6 +1,12 @@
 <p>Validatons Show Page </p>
 
-<h1><% if @validation.validated? %>Home Validated<% end %></h1>
+<h1>
+  <% if @validation.validated? %>
+  Home Validated
+  <% else %>
+  Home Not Valid
+  <% end %>
+</h1>
 
 <div class="address_report">
     <p>Information on the home you just submitted for validation</p>

--- a/fixtures/vcr_cassettes/feature_validation_iteration_1_sad_path.yml
+++ b/fixtures/vcr_cassettes/feature_validation_iteration_1_sad_path.yml
@@ -1,0 +1,117 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://maps.googleapis.com/maps/api/geocode/json?address=1510+Blake+St%2CDenver%2CCO%2C%5B%2280202%22%5D&key=AIzaSyCY5n5pb4MT_HYRFMlXUJTqM_Oe_ifEAus
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      content-type:
+      - application/json; charset=UTF-8
+      date:
+      - Thu, 09 Jun 2016 20:18:43 GMT
+      expires:
+      - Fri, 10 Jun 2016 20:18:43 GMT
+      cache-control:
+      - public, max-age=86400
+      vary:
+      - Accept-Language
+      access-control-allow-origin:
+      - "*"
+      server:
+      - mafe
+      content-length:
+      - '539'
+      x-xss-protection:
+      - 1; mode=block
+      x-frame-options:
+      - SAMEORIGIN
+      alternate-protocol:
+      - 443:quic
+      alt-svc:
+      - quic=":443"; ma=2592000; v="34,33,32,31,30,29,28,27,26,25"
+      connection:
+      - close
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        {
+           "results" : [
+              {
+                 "address_components" : [
+                    {
+                       "long_name" : "1510",
+                       "short_name" : "1510",
+                       "types" : [ "street_number" ]
+                    },
+                    {
+                       "long_name" : "Blake Street",
+                       "short_name" : "Blake St",
+                       "types" : [ "route" ]
+                    },
+                    {
+                       "long_name" : "LoDo",
+                       "short_name" : "LoDo",
+                       "types" : [ "neighborhood", "political" ]
+                    },
+                    {
+                       "long_name" : "Denver",
+                       "short_name" : "Denver",
+                       "types" : [ "locality", "political" ]
+                    },
+                    {
+                       "long_name" : "Denver County",
+                       "short_name" : "Denver County",
+                       "types" : [ "administrative_area_level_2", "political" ]
+                    },
+                    {
+                       "long_name" : "Colorado",
+                       "short_name" : "CO",
+                       "types" : [ "administrative_area_level_1", "political" ]
+                    },
+                    {
+                       "long_name" : "United States",
+                       "short_name" : "US",
+                       "types" : [ "country", "political" ]
+                    },
+                    {
+                       "long_name" : "80202",
+                       "short_name" : "80202",
+                       "types" : [ "postal_code" ]
+                    }
+                 ],
+                 "formatted_address" : "1510 Blake St, Denver, CO 80202, USA",
+                 "geometry" : {
+                    "location" : {
+                       "lat" : 39.7496354,
+                       "lng" : -105.0001058
+                    },
+                    "location_type" : "ROOFTOP",
+                    "viewport" : {
+                       "northeast" : {
+                          "lat" : 39.75098438029149,
+                          "lng" : -104.9987568197085
+                       },
+                       "southwest" : {
+                          "lat" : 39.74828641970849,
+                          "lng" : -105.0014547802915
+                       }
+                    }
+                 },
+                 "place_id" : "ChIJq7eg-cR4bIcRnuNXt5uiEvc",
+                 "types" : [ "street_address" ]
+              }
+           ],
+           "status" : "OK"
+        }
+    http_version: 
+  recorded_at: Thu, 09 Jun 2016 20:18:43 GMT
+recorded_with: VCR 3.0.3

--- a/spec/features/landlord_can_validate_homes_spec.rb
+++ b/spec/features/landlord_can_validate_homes_spec.rb
@@ -33,7 +33,39 @@ RSpec.feature "LandlordCanValidateHomes", type: :feature do
       end
     end
   end
-  
+
+    scenario "first iteration - bad photo info" do
+    VCR.use_cassette "feature_validation_iteration_1_sad_path" do
+      landlord = create(:user)
+      ApplicationController.any_instance.stubs(:current_user).returns(landlord)
+      visit validation_path
+      within ".address_submission" do
+        fill_in "Address 1", with: "1510 Blake St"
+        fill_in "City", with: "Denver"
+        fill_in "State", with: "CO"
+        fill_in "Zip", with: "80202"
+        fill_in "Lat", with: "40.74963758333333"
+        fill_in "Long", with: "-104.99990080555555"
+      end
+      click_on "Validate"
+      expect(current_path).to eq("/validations/#{Validation.last.id}")
+      within "h1" do
+        expect(page).to have_content("Home Not Valid")
+      end
+      within ".address_report" do
+        expect(page).to have_content("1510 Blake St")
+        expect(page).to have_content("CO")
+        expect(page).to have_content("80202")
+        expect(page).to have_content("39.7496354")
+        expect(page).to have_content("-105.0001058")        
+      end
+      within ".metadata" do
+        expect(page).to have_content("40.74963758333333")
+        expect(page).to have_content("-104.99990080555555")
+      end
+    end
+  end
+
   xscenario "landlord is logged in do" do
     VCR.use_cassette "feature_landlord_one_home" do
 # As a logged in landlord,


### PR DESCRIPTION
Now landlord who does not enter photo gps info that matches gmaps api
info re home address gets told validation is invalid on show page

closes #11 
